### PR TITLE
Update to makefiles to compile on Debian/CFEngine 3.15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 # Make with:
 # 
-# make CFENGINE_SOURCE=/path/to/cfengine/source CFENGINE_INSTALLDIR=/path/to/cfengine/installdir
+# make CFENGINE_SOURCE=/path/to/cfengine/source CFENGINE_PREFIX=/path/to/cfengine/installdir
 #
 CC=gcc -std=gnu99
 
 CFENGINE_SOURCE=/usr/local/src
-CFENGINE_PREFIX=/usr/local
-CFLAGS=-I$(CFENGINE_PREFIX)/include -I$(CFENGINE_SOURCE) -I$(CFENGINE_SOURCE)/libutils -I$(CFENGINE_SOURCE)/libpromises -I$(CFENGINE_SOURCE)/libcfnet
+CFENGINE_PREFIX=/var/cfengine
+CFLAGS=-I$(CFENGINE_PREFIX)/include -I$(CFENGINE_SOURCE) -I$(CFENGINE_SOURCE)/libntech/libutils -I$(CFENGINE_SOURCE)/libpromises -I$(CFENGINE_SOURCE)/libcfnet
 
 UNAME_S := $(shell uname -s)
 
@@ -24,10 +24,13 @@ endif
 
 ifeq ($(UNAME_S),Linux)
 	# Linux
-	LDFLAGS=-L$(CFENGINE_PREFIX)/lib
+	LDFLAGS=-L$(CFENGINE_PREFIX)/lib -L$(CFENGINE_SOURCE)/libpromises/.libs
 	LDLIBS=-Wl,-rpath,$(CFENGINE_PREFIX)/lib -lpromises -lcrypto
 endif
 
 OBJECTS=cf-keycrypt
 
 all: $(OBJECTS)
+
+clean:
+	rm -f cf-keycrypt

--- a/README.md
+++ b/README.md
@@ -1,7 +1,90 @@
-cf-keycrypt
-===========
+# cf-keycrypt
 
-Build with:
+This version is the same C code as the original from [cfengineers](https://github.com/cfengineers-net/cf-keycrypt).
+The only thing I updated are both
+the `Makefile` and `debian/rules`, so that cf-keycrypt compiles on Debian Linux 10 and works with
+CFEngine 3.15. Following these instructions you should be able to compile the tool yourself.
 
-```make
-# make CFENGINE_SOURCE=/path/to/cfengine/source CFENGINE_PREFIX=/path/to/cfengine/installdir
+# Prerequisites
+
+## Install prerequisite packages
+
+Whether you want to build a plain binary or a Debian package, you must be able to compile the CFEngine sources on your system. In addition, cf-keycrypt requires the development files for libtokyocabinet and the cfengine community package to be installed.
+
+Assuming that you have already installed cfengine-community on the system, to install the rest of prerequisites, run:
+
+```
+sudo apt-get install \
+    bison flex binutils build-essential \
+    pkg-config autoconf libtool liblmdb-dev \
+    libssl-dev libpcre3-dev libpam0g-dev \
+    git libtokyocabinet-dev
+```
+
+If you need to install the cfengine-community package, refer to [this page](https://cfengine.com/product/community/) on the official web site.
+
+## Clone the cf-keycrypt repository
+
+In a directory of your choice, run:
+
+```
+git clone git@github.com:brontolinux/cf-keycrypt.git
+```
+
+
+# Building the binary
+
+## Clone the cfengine core repository
+
+To clone the latest 3.15 branch, run the following command in a directory of your choice:
+
+```
+git clone --recursive --single-branch --branch 3.15.x git@github.com:cfengine/core.git
+```
+
+## Build CFEngine 3.15
+
+Enter the `core` directory and run:
+
+```
+./autogen.sh -C
+make
+```
+
+## Compile cf-keycrypt
+
+Assuming that you cloned and compiled CFEngine in, say, `/usr/local/src/cfengine/core`, enter the `cf-keycrypt` directory and run
+
+```
+make CFENGINE_SOURCE=/usr/local/src/cfengine/core
+```
+
+This should return pretty fast. If there are no errors, you'll find a `cf-keycrypt` executable in the directory where you cloned the sources. Congratulations.
+
+# Building a Debian package
+
+Enter the directory where you cloned cf-keycrypt and run:
+
+```
+sudo dpkg-buildpackage -us -uc
+```
+
+In a little while a number of files will be created in the directory above the source directory:
+
+```
+cf-keycrypt-dbgsym_0.1.1_amd64.deb
+cf-keycrypt_0.1.1.dsc
+cf-keycrypt_0.1.1.tar.xz
+cf-keycrypt_0.1.1_amd64.buildinfo
+cf-keycrypt_0.1.1_amd64.changes
+cf-keycrypt_0.1.1_amd64.deb
+```
+
+You are probably most interested in `cf-keycrypt_0.1.1_amd64.deb`.
+
+That's it!
+
+
+# Acknowledgements
+
+Instructions about how to compile CFEngine from source on a Debian system were kindly provided by Vratislav Podzimek and double checked by Bas van der Vlies. The tinkering on makefiles to make this compile on Debian is mine.

--- a/cf-keycrypt.c
+++ b/cf-keycrypt.c
@@ -26,7 +26,8 @@
 
 #include <lastseen.h>
 #include <conversion.h>
-#include <files_hashes.h>
+// #include <files_hashes.h>
+#include <hash.h>
 #include <locks.h>
 #include <item_lib.h>
 #include <known_dirs.h>

--- a/debian/rules
+++ b/debian/rules
@@ -17,6 +17,7 @@ include /usr/share/dpkg/default.mk
 #export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
 CF_SRC = /tmp/cf-keycrypt-cf3src
+CF_BRANCH = 3.15.x
 
 clean:
 	rm -f cf-keycrypt
@@ -25,9 +26,9 @@ clean:
 
 binary:
 	mkdir -p $(CF_SRC)
-	git clone https://github.com/cfengine/core.git $(CF_SRC)
+	git clone --recursive --single-branch --branch $(CF_BRANCH) https://github.com/cfengine/core.git $(CF_SRC)
 	cd $(CF_SRC) ; ./autogen.sh ; make
-	gcc -std=gnu99 -I/var/cfengine/include -I$(CF_SRC) -I$(CF_SRC)/libutils -I$(CF_SRC)/libpromises -I$(CF_SRC)/libcfnet  -L$(CF_SRC)/libpromises/.libs cf-keycrypt.c -Wl,-rpath,/var/cfengine/lib/ -lpromises -lcrypto -o cf-keycrypt
+	gcc -std=gnu99 -I/var/cfengine/include -I$(CF_SRC) -I$(CF_SRC)/libntech/libutils -I$(CF_SRC)/libpromises -I$(CF_SRC)/libcfnet  -L$(CF_SRC)/libpromises/.libs cf-keycrypt.c -Wl,-rpath,/var/cfengine/lib/ -lpromises -lcrypto -o cf-keycrypt
 	rm -rf $(CF_SRC) 
 	dh $@
 


### PR DESCRIPTION
- updated Makefile
- updated debian/rules
- updated cf-keycrypt (renamed include file)
- updated README.md

README now includes extensive instructions to compile cf-keycrypt
on Debian Linux 10, both as an independent binary and as a deb
package.